### PR TITLE
Fix "too few arguments in function call" error in sum_package, when total integral is contour deformed, but some sub-integrals are not

### DIFF
--- a/pySecDec/code_writer/templates/sum_package/src/name_weighted_integral.cpp
+++ b/pySecDec/code_writer/templates/sum_package/src/name_weighted_integral.cpp
@@ -430,7 +430,7 @@ namespace %(name)s
             (
                 real_parameters,
                 complex_parameters
-                #if %(sub_integral_name)s_contour_deformation
+                #if %(name)s_contour_deformation
                     ,number_of_presamples,
                     deformation_parameters_maximum,
                     deformation_parameters_minimum,


### PR DESCRIPTION
If the total integral has contour deformation, but one (or more) of the sub-integrals does not, there is an error thrown during compilation because the "types::make_integrand" function is called with too few parameters. 

On line 433, this needs to be "#if %(name)s_contour_deformation" so that the make_integrands function is called on line 76 or 111 with the correct number of parameters. The "#if %(sub_integral_names)s_contour_deformation" case (that was originally being handled on line 433) is still taken care of, on line 92 or 127.