### PR TITLE
fix some typos, wrong multiple imports on one line, some rst syntax

### DIFF
--- a/doc/setup.py
+++ b/doc/setup.py
@@ -1,2 +1,3 @@
-import sys, os
+import sys
+import os
 exit(os.system(f"{sys.executable} -m SCons pySecDec/metadata.py"))

--- a/examples/bubble1L_dotted_ebr/generate_bubble1L_dotted_ebr.py
+++ b/examples/bubble1L_dotted_ebr/generate_bubble1L_dotted_ebr.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         replacement_rules = [('p*p', 'psq'), ('msq_', 'msq')]
     )
 
-    # define the loop integeral for the case where we expand in z
+    # define the loop integral for the case where we expand in z
     li_z = LoopIntegralFromPropagators(
         propagators=li_m.propagators,
         loop_momenta=li_m.loop_momenta,

--- a/examples/elliptic2L_physical/README.disteval
+++ b/examples/elliptic2L_physical/README.disteval
@@ -17,7 +17,7 @@ and finally integrate (locally):
         --epsrel=3e-5
 
 The option `--epsrel=3e-5` will make the evaluator integrate in
-the adaptive mode untill this precision is reached.
+the adaptive mode until this precision is reached.
 
 Use the option `--points=1e6` to specify the initial lattice size
 on which all integrals will be evaluated in the first iteration.

--- a/examples/jupyter/muon_production.ipynb
+++ b/examples/jupyter/muon_production.ipynb
@@ -333,7 +333,7 @@
    "id": "a3821779",
    "metadata": {},
    "source": [
-    "#### Formating results\n",
+    "#### Formatting results\n",
     "Express results in terms of the QED fine structure constant $\\alpha$ and reinclude the factor of $2\\pi$ which had been removed from the coefficients earlier. In natural units the relation between the QED fine structure constant and the electric charge is $e^2=4\\pi\\alpha$. "
    ]
   },

--- a/high_level_tests/README
+++ b/high_level_tests/README
@@ -22,12 +22,12 @@ make <dirname>:
    Run 'make test' in the directory <dirname>.
 
 
-FUTHER OPTIONS
-==============
+FURTHER OPTIONS
+===============
 
-You can set the environemnt variable CUBACORES to the number of cores to be
+You can set the environment variable CUBACORES to the number of cores to be
 used for the numerical integrations. Make's "-j<jmake>" option controls how
-many recipies make executes in parallel. To run up to four instances of make
+many recipes make executes in parallel. To run up to four instances of make
 and use two cores for each numerical integration run 'CUBACORES=4 make -j2'.
 Note that make may start up to <jmake> integrations in parallel such that
 you will have up to "<jmake> * CUBACORES" threads running in parallel.
@@ -45,4 +45,4 @@ Some tests can run the numerical integration on GPUs using CUDA.
 In order to enable CUDA, set the environment variables 'CXX=nvcc'
 and 'SECDEC_WITH_CUDA_FLAGS=-arch=<target CUDA arch>' (try e.g.
 sm_52 if you are not sure), see the "Building the C++ Library" in
-the "Getting Started" section of the documentaion for details.
+the "Getting Started" section of the documentation for details.

--- a/high_level_tests/make_package_tadpole2L_rank2/tadpole2L_rank2.py
+++ b/high_level_tests/make_package_tadpole2L_rank2/tadpole2L_rank2.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     # contour deformation is not required because there are no external legs
     contour_deformation = False,
 
-    # make sure the retun type is double
+    # make sure the return type is double
     enforce_complex = True,
 
     package_generator=psd.code_writer.make_package

--- a/high_level_tests/tadpole2L_rank2/tadpole2L_rank2.py
+++ b/high_level_tests/tadpole2L_rank2/tadpole2L_rank2.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     # contour deformation is not required because there are no external legs
     contour_deformation = False,
 
-    # make sure the retun type is double
+    # make sure the return type is double
     enforce_complex = True,
 
     )

--- a/high_level_tests/test_suite/catch_amalgamated.cpp
+++ b/high_level_tests/test_suite/catch_amalgamated.cpp
@@ -596,7 +596,7 @@ namespace Catch {
             elem = trim(elem);
         }
 
-        // Insert the default reporter if user hasn't asked for a specfic one
+        // Insert the default reporter if user hasn't asked for a specific one
         if ( m_data.reporterSpecifications.empty() ) {
             m_data.reporterSpecifications.push_back( {
 #if defined( CATCH_CONFIG_DEFAULT_REPORTER )
@@ -5296,7 +5296,7 @@ namespace Catch {
         auto& currentTracker = m_trackerContext.currentTracker();
         assert(
             currentTracker.nameAndLocation() != nameAndLoc &&
-            "Trying to create tracker for a genreator that already has one" );
+            "Trying to create tracker for a generator that already has one" );
 
         auto newTracker = Catch::Detail::make_unique<Generators::GeneratorTracker>(
             CATCH_MOVE(nameAndLoc), m_trackerContext, &currentTracker );

--- a/high_level_tests/test_suite/catch_amalgamated.hpp
+++ b/high_level_tests/test_suite/catch_amalgamated.hpp
@@ -1603,7 +1603,7 @@ namespace Catch {
          */
         virtual void skipTest( TestCaseInfo const& testInfo ) = 0;
 
-        //! Called if a fatal error (signal/structured exception) occured
+        //! Called if a fatal error (signal/structured exception) occurred
         virtual void fatalErrorEncountered( StringRef error ) = 0;
 
         //! Writes out information about provided reporters using reporter-specific format
@@ -9448,7 +9448,7 @@ namespace TestCaseTracking {
 
         //! Returns true if tracker run to completion (successfully or not)
         virtual bool isComplete() const = 0;
-        //! Returns true if tracker run to completion succesfully
+        //! Returns true if tracker run to completion successfully
         bool isSuccessfullyCompleted() const {
             return m_runState == CompletedSuccessfully;
         }
@@ -10132,7 +10132,7 @@ namespace Catch {
                 // Calculates the length of the current line
                 void calcLength();
 
-                // Returns current indention width
+                // Returns current indentation width
                 size_t indentSize() const;
 
                 // Creates an indented and (optionally) suffixed string from
@@ -11680,7 +11680,7 @@ namespace Catch {
 
         /**
          * Creates a matcher that checks if all elements in a range are equal
-         * to all elements in another range, in some permuation.
+         * to all elements in another range, in some permutation.
          *
          * Uses to provided predicate `predicate` to do the comparisons
          */
@@ -12358,7 +12358,7 @@ namespace Catch {
         void skipTest(TestCaseInfo const&) override {}
 
     protected:
-        //! Should the cumulative base store the assertion expansion for succesful assertions?
+        //! Should the cumulative base store the assertion expansion for successful assertions?
         bool m_shouldStoreSuccesfulAssertions = true;
         //! Should the cumulative base store the assertion expansion for failed assertions?
         bool m_shouldStoreFailedAssertions = true;

--- a/nodist_examples/LoPresti/generate_I73.py
+++ b/nodist_examples/LoPresti/generate_I73.py
@@ -3,7 +3,9 @@
 from pySecDec.loop_integral import LoopIntegralFromPropagators, LoopPackage
 from pySecDec.code_writer.sum_package import sum_package, Coefficient
 from itertools import repeat
-import re, sympy as sp, numpy as np
+import re
+import sympy as sp
+import numpy as np
 
 # arXiv:1809.06240
 

--- a/nodist_examples/LoPresti/integrate_I73.cpp
+++ b/nodist_examples/LoPresti/integrate_I73.cpp
@@ -40,7 +40,7 @@ int main()
     // Note: The integrals themselves may also be computed in parallel irresprective of this option.
     amplitude.number_of_threads = 16;
 
-    // The cuda driver does not automatically remove unneccessary functions from the device memory
+    // The cuda driver does not automatically remove unnecessary functions from the device memory
     // such that the device may run out of memry after some time. This option controls how many
     // after how many integrals "cudaDeviceReset()" is called to clear the memory. With the default
     // "0", "cudaDeviceReset()" is never called. This option is ignored if compiled without cuda.

--- a/nodist_examples/box2L_pp/generate.py
+++ b/nodist_examples/box2L_pp/generate.py
@@ -59,7 +59,7 @@ def parse_integral(line, families, args):
     return package_args
 
 def parse_coefficient(line, dimension_symbol, args):
-    '''Decomposes the coefficent into numerator and denominator and \
+    '''Decomposes the coefficient into numerator and denominator and \
     calculates the order of epsilon of the coefficient.'''
     d = sp.symbols(dimension_symbol)
     eps = sp.symbols("eps")

--- a/nodist_examples/box2L_pp/integrate_AA_F3_1_1_1_1_1_1_1_0_0.cpp
+++ b/nodist_examples/box2L_pp/integrate_AA_F3_1_1_1_1_1_1_1_0_0.cpp
@@ -37,7 +37,7 @@ int main()
     // Note: The integrals themselves may also be computed in parallel irresprective of this option.
     // amplitude.number_of_threads = 12;
 
-    // The cuda driver does not automatically remove unneccessary functions from the device memory
+    // The cuda driver does not automatically remove unnecessary functions from the device memory
     // such that the device may run out of memry after some time. This option controls how many
     // after how many integrals "cudaDeviceReset()" is called to clear the memory. With the default
     // "0", "cudaDeviceReset()" is never called. This option is ignored if compiled without cuda.
@@ -47,7 +47,7 @@ int main()
     // Note: The integrals themselves may also be computed in parallel irresprective of this option.
     // amplitude.number_of_threads = 12;
 
-    // The cuda driver does not automatically remove unneccessary functions from the device memory
+    // The cuda driver does not automatically remove unnecessary functions from the device memory
     // such that the device may run out of memry after some time. This option controls how many
     // after how many integrals "cudaDeviceReset()" is called to clear the memory. With the default
     // "0", "cudaDeviceReset()" is never called. This option is ignored if compiled without cuda.

--- a/nodist_examples/gggH1L/integrate_gggH1L.py
+++ b/nodist_examples/gggH1L/integrate_gggH1L.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     amp2 = IntegralLibrary('F312/F312_pylink.so')
 
     # choose Qmc integrator
-    # amp.use_Qmc()  # Qmc doesnt work as of now for new version, try Vegas  # amp.use_Vegas()
+    # amp.use_Qmc()  # Qmc doesn't work as of now for new version, try Vegas  # amp.use_Vegas()
     amp1.use_Qmc()
     amp2.use_Qmc()
 
@@ -197,7 +197,7 @@ if __name__ == "__main__":
 
     # Use the form factor values to calculate the Mod Squared Amplitude
 
-    # Set the dimesnions as 4 because Form Factors dont have divergent terms of epsilon -> we can safely substitute eps = 0 now
+    # Set the dimensions as 4 because Form Factors dont have divergent terms of epsilon -> we can safely substitute eps = 0 now
     #dim = 4
     
     # Because we are dealing with normalised form factors, conjugate dont have effect
@@ -260,7 +260,7 @@ if __name__ == "__main__":
     #print('---------------------------------------------------------------')
     #print('Multiply Above Number with ( ( Nc*(Nc^2 -1) )*(topmass^4)*(alpha_S^3) / pi*(v^2) )  To Get The Final Ampltiude Squared, which can then be averaged over colors and gluon polraisations ')
     #print('---------------------------------------------------------------')
-    #print('Both Numerical and Analytic Amplitudes have been eveluated at these conditions :  [ s12, s13, s23, topmass^2, hmass^2 ]  = [ ',s1,', ',s2,', ',s3,', ',(topmass*topmass),', ',(hmass*hmass),' ]')
+    #print('Both Numerical and Analytic Amplitudes have been evaluated at these conditions :  [ s12, s13, s23, topmass^2, hmass^2 ]  = [ ',s1,', ',s2,', ',s3,', ',(topmass*topmass),', ',(hmass*hmass),' ]')
     #print('---------------------------------------------------------------')
 
 

--- a/nodist_examples/pentabox2L/pentabox2L.py
+++ b/nodist_examples/pentabox2L/pentabox2L.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from pySecDec.loop_integral import loop_package
-import pySecDec as psd, sympy as sp
+import pySecDec as psd
+import sympy as sp
 
 if __name__ == "__main__":
 

--- a/pySecDec/algebra.py
+++ b/pySecDec/algebra.py
@@ -11,6 +11,7 @@ from .misc import argsort_2D_array, argsort_ND_array, doc, \
 import numpy as np
 import sympy as sp
 
+
 class _Expression(object):
     '''
     Abstract base class for all expressions in this
@@ -211,11 +212,11 @@ class Function(_Expression):
             ``dfd<index>``.
 
         '''
-        def update(repository, multiindex, recipies, expression):
+        def update(repository, multiindex, recipes, expression):
             '''
             Recursively compute all intermediate derivatives
             of `expression` indicated by `multiindex` using
-            `recipies` and add them to the `repository`.
+            `recipes` and add them to the `repository`.
             Return the derivative indicated by `multiindex`.
 
             '''
@@ -228,8 +229,8 @@ class Function(_Expression):
                     return expression
                 else:
                     # must compute the derivative from a lower derivative
-                    index, lower_multiindex = recipies[multiindex]
-                    required_derivative = update(repository, lower_multiindex, recipies, expression).derive(index).simplify()
+                    index, lower_multiindex = recipes[multiindex]
+                    required_derivative = update(repository, lower_multiindex, recipes, expression).derive(index).simplify()
                     repository[multiindex] = required_derivative
                     return required_derivative
 

--- a/pySecDec/code_writer/templates/sum_package/pylink/pylink.cpp
+++ b/pySecDec/code_writer/templates/sum_package/pylink/pylink.cpp
@@ -25,7 +25,7 @@
 #include <secdecutil/pylink.hpp> // The python-C binding is general and therefore contained in the util
 #include <secdecutil/pylink_amplitude.hpp>
 
-// delegate some template instatiations to separate translation units
+// delegate some template instantiations to separate translation units
 #ifdef SECDEC_WITH_CUDA
     #define EXTERN_NONE_QMC_SEPARATE() \
         extern template class secdecutil::integrators::Qmc< \

--- a/pySecDec/code_writer/test_make_package.py
+++ b/pySecDec/code_writer/test_make_package.py
@@ -6,7 +6,8 @@ from .make_package import _convert_input, _make_FORM_definition, \
                           _make_CXX_function_declaration
 from ..algebra import Function, Polynomial, Product, ProductRule, Sum
 from ..misc import sympify_expression
-import sys, shutil
+import sys
+import shutil
 import unittest
 import pytest
 

--- a/pySecDec/code_writer/test_template_parser.py
+++ b/pySecDec/code_writer/test_template_parser.py
@@ -1,5 +1,7 @@
 from .template_parser import *
-import sys, os, shutil
+import sys
+import os
+import shutil
 import unittest
 import pytest
 

--- a/pySecDec/decomposition/test_common.py
+++ b/pySecDec/decomposition/test_common.py
@@ -7,7 +7,8 @@ import unittest
 import sympy as sp
 import numpy as np
 from itertools import permutations
-import sys, os
+import sys
+import os
 import shutil
 import pytest
 

--- a/pySecDec/disteval.py
+++ b/pySecDec/disteval.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """
 Distributed and/or local evaluator for pySecDec integrals.
-Usage:
+
+Usage::
+
     python3 -m pySecDec.disteval integrand.json [options] <var>=value ...
-Options:
+
+Options::
+
     --epsabs=X              stop if this absolute precision is reached (default: 1e-10)
     --epsrel=X              stop if this relative precision is reached (default: 1e-4)
     --timeout=X             stop after at most this many seconds (default: inf)
@@ -15,7 +19,9 @@ Options:
     --format=X              output the result in this format ("sympy", "mathematica", "json")
     --lattice-candidates=X  number of median lattice candidates, if X>0 (default: 0)
     --help                  show this help message
-Arguments:
+
+Arguments::
+
     <var>=X                 set this integral or coefficient variable to a given value
     int-<var>=X             set this integral variable to a given value
     coeff-<var>=X           set this coefficient variable to a given value

--- a/pySecDec/disteval_benchmark.py
+++ b/pySecDec/disteval_benchmark.py
@@ -3,13 +3,19 @@
 Benchmark the evaluation rate (i.e. evaluations per second) of
 disteval kernels in a given integral sum. Print the resulting
 evaluation rates in a comma-separated value (CSV) format.
-Usage:
+
+Usage::
+
     python3 -m pySecDec.disteval_benchmark integrand.json [options] <var>=value ...
-Options:
+
+Options::
+
     --points=X          evaluate using this many points per batch (default: 1e5)
     --repetitions=X     repeat the measurement this many times (default: 10)
     --help              show this help message
-Arguments:
+
+Arguments::
+
     <var>=X             set this integral or coefficient variable to a given value
 """
 

--- a/pySecDec/loop_integral/draw.py
+++ b/pySecDec/loop_integral/draw.py
@@ -1,6 +1,7 @@
 'Routines to draw Feynman diagrams'
 
-import subprocess, os
+import subprocess
+import os
 
 def plot_diagram(internal_lines, external_lines, filename, powerlist=None, neato='neato', extension='pdf', Gstart=0):
     '''

--- a/pySecDec/loop_integral/test_draw.py
+++ b/pySecDec/loop_integral/test_draw.py
@@ -1,5 +1,6 @@
 from .draw import *
-import sys, os
+import sys
+import os
 import unittest
 import pytest
 


### PR DESCRIPTION
nothing fancy:

- fixing a few typos found using `codespell`
- fixing using `ruff` the multiple import on one line (ruff code E401)
- fixing rst syntax in two files